### PR TITLE
Do not use ephemeral package when the flag 'worker_harness_container_…

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -67,6 +67,8 @@
 *   The `tfx.dsl.io.fileio` filesystem handler will delegate to
     `tensorflow.io.gfile` for any unknown filesystem schemes if TensorFlow
     is installed.
+*   Skipped ephemeral package when the beam flag
+    'worker_harness_container_image' is set.
 *   Depends on `apache-beam[gcp]>=2.25,!=2.26,<3`.
 *   Depends on `keras-tuner>=1,<1.0.2`.
 *   Depends on `kfp-pipeline-spec>=0.1.3,<0.2`.

--- a/tfx/utils/dependency_utils.py
+++ b/tfx/utils/dependency_utils.py
@@ -51,7 +51,10 @@ def make_beam_dependency_flags(beam_pipeline_args: List[Text]) -> List[Text]:
   pipeline_options = beam.options.pipeline_options.PipelineOptions(
       flags=beam_pipeline_args)
   all_options = pipeline_options.get_all_options()
-  for flag_name in ['extra_packages', 'setup_file', 'requirements_file']:
+  for flag_name in [
+      'extra_packages', 'setup_file', 'requirements_file',
+      'worker_harness_container_image'
+  ]:
     if all_options.get(flag_name):
       absl.logging.info('Nonempty beam arg %s already includes dependency',
                         flag_name)


### PR DESCRIPTION
…image' is set.

In such a case, users can usually extend TFX image, or build a docker image which includes TFX and its dependencies in PYTHON_PATH easily, so the ephemeral package only adds confusion instead of convenience.

PiperOrigin-RevId: 350077955